### PR TITLE
Disable Chess Menu when "viewOnly: true"

### DIFF
--- a/src/Chesser.ts
+++ b/src/Chesser.ts
@@ -173,7 +173,9 @@ export class Chesser extends MarkdownRenderChild {
       });
     }
 
-    this.menu = new ChesserMenu(containerEl, this);
+    if (!config.viewOnly) {
+      this.menu = new ChesserMenu(containerEl, this);
+    }
   }
 
   private set_style(el: HTMLElement, pieceStyle: string, boardStyle: string) {


### PR DESCRIPTION
# Context
Before this commit, creating a chessboard with the following snippet would show a menu beside the board despite a `viewOnly: true` setting. This seems unintentional given that bug https://github.com/SilentVoid13/Chesser/issues/8: _No way to disable the menu next to the chess board_ has been open for months.

```chesser
fen: r1bqkb1r/pppp1ppp/2n2n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4
id: V-wi7vRs
viewOnly: true
```

After this commit, the menu disappears when `viewOnly: true`.

# Testing
Ran the plugin locally following https://marcus.se.net/obsidian-plugin-docs/getting-started/create-your-first-plugin and verified that the snippet above displays no menu when using my change.

# Other Notes
- It looks like this only disabled the menu when `viewOnly: true` is set in the `chesser` block. The global plugin `viewOnly` settings appear to not disable the menu.
- The chessboard is left-aligned when the menu is disabled. This seems unrelated to my commit?

