### PR TITLE
Starting positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Here are the available settings for a `chesr` code block:
 | `drawable`    | `true`/`false`                                               | Controls the ability to draw annotations (arrows, circles) on the board. |
 | `viewOnly`    | `true`/`false`                                               | If enabled, displays a static chess board (no moves, annotations, ...). |
 | `free`        | `true`/`false`                                               | If enabled, disables the chess logic, all moves are valid.   |
+| `startingPosition`| The name of a starting position (e.g., `Queen's Gambit`) or ECO string (e.g., `D06`)  | Starts the chess board with a particular opening |
 
 You can permanently set some settings in [Chesser](https://github.com/SilentVoid13/Chesser)'s obsidian plugin settings.
 

--- a/src/Chesser.ts
+++ b/src/Chesser.ts
@@ -59,6 +59,9 @@ import "../assets/board-css/green.css";
 import "../assets/board-css/purple.css";
 import "../assets/board-css/ic.css";
 import debug from "./debug";
+import startingPositions from "./startingPositions"
+import { readFileSync } from "fs";
+import { start } from "repl";
 
 export function draw_chessboard(app: App, settings: ChesserSettings) {
   return (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
@@ -126,7 +129,20 @@ export class Chesser extends MarkdownRenderChild {
     if (config.pgn) {
       debug(() => console.debug("loading from pgn", config.pgn));
       this.chess.load_pgn(config.pgn);
-    } else if (config.fen) {
+    } else if (config.startingPosition) { 
+      debug(() => console.debug("loading from starting position ", config.startingPosition));
+      let positions = startingPositions.flatMap((cat) => cat.items)
+      const startingPosition = positions.find((item) => item.name === config.startingPosition) ?? 
+                               positions.find((item) => item.eco === config.startingPosition);
+      if (startingPosition) {
+        this.loadFen(startingPosition.fen, startingPosition.moves)
+      }
+      else {
+        new Notice("Chesser: Unable to find starting position " + config.startingPosition)
+      }
+      
+    }
+    else if (config.fen) {
       debug(() => console.debug("loading from fen", config.fen));
       this.chess.load(config.fen);
     }

--- a/src/Chesser.ts
+++ b/src/Chesser.ts
@@ -125,6 +125,8 @@ export class Chesser extends MarkdownRenderChild {
         });
       });
     }
+    
+    this.cg = Chessground(containerEl.createDiv())
 
     if (config.pgn) {
       debug(() => console.debug("loading from pgn", config.pgn));
@@ -159,7 +161,7 @@ export class Chesser extends MarkdownRenderChild {
     // Setup UI
     this.set_style(containerEl, config.pieceStyle, config.boardStyle);
     try {
-      this.cg = Chessground(containerEl.createDiv(), {
+      this.cg.set({
         fen: this.chess.fen(),
         addDimensionsCssVars: true,
         lastMove,

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -1,6 +1,6 @@
 import { setIcon, Setting } from "obsidian";
 import { Chesser } from "./Chesser";
-import startingPositons from "./startingPositions";
+import startingPositions from "./startingPositions";
 
 export default class ChesserMenu {
   private chesser: Chesser;
@@ -29,7 +29,7 @@ export default class ChesserMenu {
             });
             el.createEl("optgroup", {}, (optgroup) => {
               optgroup.label = "Popular Openings";
-              startingPositons.forEach((category) => {
+              startingPositions.forEach((category) => {
                 category.items.forEach((item) => {
                   optgroup.createEl("option", {
                     value: item.eco,
@@ -58,7 +58,7 @@ export default class ChesserMenu {
             return;
           }
 
-          const startingPosition = startingPositons
+          const startingPosition = startingPositions
             .flatMap((cat) => cat.items)
             .find((item) => item.eco === value);
 
@@ -83,7 +83,7 @@ export default class ChesserMenu {
   }
 
   getStartingPositionFromFen(fen: string) {
-    return startingPositons.flatMap((cat) => cat.items).find((item) => item.eco === fen);
+    return startingPositions.flatMap((cat) => cat.items).find((item) => item.eco === fen);
   }
 
   createToolbar() {


### PR DESCRIPTION
This PR adds a new config key, `startingPosition`, which can be set to the name of a starting position or its ECO string. Setting this key initializes the board to the given position.