### PR TITLE
Auto focus active move

### DIFF
--- a/src/menu.ts
+++ b/src/menu.ts
@@ -152,8 +152,7 @@ export default class ChesserMenu {
           }`,
           text: move.san,
         });
-        if(this.chesser.currentMoveIdx === idx)
-        {
+        if (this.chesser.currentMoveIdx === idx) {
           activeElement = moveEl;
         }
         moveEl.addEventListener("click", (ev) => {

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -137,6 +137,8 @@ export default class ChesserMenu {
   }
 
   redrawMoveList() {
+    const currentScroll = this.movesListEl.find(".chess-move-list")?.scrollTop || 0;
+    let activeElement : HTMLDivElement;
     this.movesListEl.empty();
     this.movesListEl.createDiv({
       text: this.chesser.turn() === "b" ? "Black's turn" : "White's turn",
@@ -150,11 +152,20 @@ export default class ChesserMenu {
           }`,
           text: move.san,
         });
+        if(this.chesser.currentMoveIdx === idx)
+        {
+          activeElement = moveEl;
+        }
         moveEl.addEventListener("click", (ev) => {
           ev.preventDefault();
           this.chesser.update_turn_idx(idx);
         });
       });
+      setTimeout(() => {
+        const activeElementOffsetTop = (activeElement?.offsetTop - moveListEl.offsetTop) || currentScroll;
+        const scrollDifference = activeElementOffsetTop - currentScroll;
+        moveListEl.scrollTop = scrollDifference > 0 && scrollDifference < 200 ? currentScroll : activeElementOffsetTop;
+      }, 0);
     });
   }
 }


### PR DESCRIPTION
Hello,

I modified the move list behavior to : 
- keep the current scroll position if the active move is in the view
- update the scroll position to match the current move if the active move is outside of the view

It's a quality of life improvement I really needed when using the plugin.

There is a flicker related to the fact we are redrawing the move list from scratch then changing the scroll position. 
To keep the code simple, I didn't touch that.