### PR TITLE
Add 'hideMenu' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Here are the available settings for a `chesr` code block:
 | `orientation` | `white`/`black`                                              | Orientation of the board.                                    |
 | `pieceStyle`  | A valid piece style name.<br />Check [this](https://github.com/SilentVoid13/Chesser/tree/master/assets/piece-css) to view available styles. | Style of the pieces on the board.                            |
 | `boardStyle`  | A valid board style name.<br />Check [this](https://github.com/SilentVoid13/Chesser/tree/master/assets/board-css) to view available styles. | Style of the chess board.                                    |
+| `hideMenu` | `true`/`false` | Hides the chess menu when enabled. |
 | `drawable`    | `true`/`false`                                               | Controls the ability to draw annotations (arrows, circles) on the board. |
 | `viewOnly`    | `true`/`false`                                               | If enabled, displays a static chess board (no moves, annotations, ...). |
 | `free`        | `true`/`false`                                               | If enabled, disables the chess logic, all moves are valid.   |

--- a/src/Chesser.ts
+++ b/src/Chesser.ts
@@ -88,7 +88,7 @@ export class Chesser extends MarkdownRenderChild {
   private cg: Api;
   private chess: Chess;
 
-  private menu: ChesserMenu;
+  private menu: ChesserMenu | null;
   private moves: Move[];
 
   public currentMoveIdx: number;
@@ -171,7 +171,7 @@ export class Chesser extends MarkdownRenderChild {
       });
     }
 
-    this.menu = new ChesserMenu(containerEl, this);
+    this.menu = config.hideMenu ? null : new ChesserMenu(containerEl, this);
   }
 
   private set_style(el: HTMLElement, pieceStyle: string, boardStyle: string) {

--- a/src/ChesserSettings.ts
+++ b/src/ChesserSettings.ts
@@ -5,6 +5,7 @@ import { App, PluginSettingTab, Setting } from "obsidian";
 
 export interface ChesserSettings {
   orientation: string;
+  hideMenu: boolean;
   viewOnly: boolean;
   drawable: boolean;
   free: boolean;
@@ -14,6 +15,7 @@ export interface ChesserSettings {
 
 export const DEFAULT_SETTINGS: ChesserSettings = {
   orientation: "white",
+  hideMenu: false,
   viewOnly: false,
   drawable: true,
   free: false,


### PR DESCRIPTION
I added a `hideMenu` boolean option with the hope of resolving issue https://github.com/SilentVoid13/Chesser/issues/8. Enabling it hides the chess menu on the side of the board.